### PR TITLE
fix: Update versions to support recent models

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -8,9 +8,9 @@ export async function CopilotAuthPlugin({ client }) {
   const COPILOT_API_KEY_URL =
     "https://api.github.com/copilot_internal/v2/token";
   const HEADERS = {
-    "User-Agent": "GitHubCopilotChat/0.26.7",
-    "Editor-Version": "vscode/1.99.3",
-    "Editor-Plugin-Version": "copilot-chat/0.26.7",
+    "User-Agent": "GitHubCopilotChat/0.31.2",
+    "Editor-Version": "vscode/1.104.1",
+    "Editor-Plugin-Version": "copilot-chat/0.31.2",
     "Copilot-Integration-Id": "vscode-chat",
   };
 
@@ -107,7 +107,7 @@ export async function CopilotAuthPlugin({ client }) {
               headers: {
                 Accept: "application/json",
                 "Content-Type": "application/json",
-                "User-Agent": "GitHubCopilotChat/0.26.7",
+                "User-Agent": "GitHubCopilotChat/0.31.2",
               },
               body: JSON.stringify({
                 client_id: CLIENT_ID,
@@ -126,7 +126,7 @@ export async function CopilotAuthPlugin({ client }) {
                     headers: {
                       Accept: "application/json",
                       "Content-Type": "application/json",
-                      "User-Agent": "GitHubCopilotChat/0.26.7",
+                      "User-Agent": "GitHubCopilotChat/0.31.2",
                     },
                     body: JSON.stringify({
                       client_id: CLIENT_ID,


### PR DESCRIPTION
This pull request updates the user agent and related version headers used in API requests to reflect the latest Copilot Chat and VS Code versions. These changes help ensure accurate client identification and compatibility with the Copilot API.

**Version and header updates:**

* Updated the `User-Agent`, `Editor-Version`, and `Editor-Plugin-Version` headers in the main request header object to use Copilot Chat version `0.31.2` and VS Code version `1.104.1` (`index.mjs`).
* Updated the `User-Agent` header in both the token fetch and refresh request headers to use Copilot Chat version `0.31.2` (`index.mjs`) [[1]](diffhunk://#diff-d6299b5bb2afc0956126a0adb12fd89829e01a4cc025e7277a092228b96f32e4L110-R110) [[2]](diffhunk://#diff-d6299b5bb2afc0956126a0adb12fd89829e01a4cc025e7277a092228b96f32e4L129-R129).

This PR enables gpt-5-codex support. Currently we are receiving this error:

```
AI_APICallError: model gpt-5-codex is not supported in this VS Code version. Please update it to version 1.104.1 or newer
```