### PR TITLE
feat: add GitHub Enterprise support

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -70,9 +70,12 @@ export async function CopilotAuthPlugin({ client }) {
 
               const tokenData = await response.json();
 
+              const saveProviderID = info.enterpriseUrl
+                ? "github-copilot-enterprise"
+                : "github-copilot";
               await client.auth.set({
                 path: {
-                  id: provider.id,
+                  id: saveProviderID,
                 },
                 body: {
                   type: "oauth",

--- a/index.mjs
+++ b/index.mjs
@@ -204,16 +204,7 @@ export async function CopilotAuthPlugin({ client }) {
               instructions: `Enter code: ${deviceData.user_code}`,
               method: "auto",
               callback: async () => {
-                const maxAttempts = Math.ceil(
-                  (deviceData.expires_in || 900) / (deviceData.interval || 5)
-                );
-                let attempts = 0;
-
-                while (attempts < maxAttempts) {
-                  await new Promise((resolve) =>
-                    setTimeout(resolve, (deviceData.interval || 5) * 1000)
-                  );
-
+                while (true) {
                   const response = await fetch(urls.ACCESS_TOKEN_URL, {
                     method: "POST",
                     headers: {
@@ -250,15 +241,19 @@ export async function CopilotAuthPlugin({ client }) {
                   }
 
                   if (data.error === "authorization_pending") {
-                    attempts++;
+                    await new Promise((resolve) =>
+                      setTimeout(resolve, deviceData.interval * 1000),
+                    );
                     continue;
                   }
 
                   if (data.error) return { type: "failed" };
-                }
 
-                // Timeout
-                return { type: "failed" };
+                  await new Promise((resolve) =>
+                    setTimeout(resolve, deviceData.interval * 1000),
+                  );
+                  continue;
+                }
               },
             };
           },

--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,7 @@
-function createCopilotPlugin(client, { providerId, isEnterprise }) {
+/**
+ * @type {import('@opencode-ai/plugin').Plugin}
+ */
+export async function CopilotAuthPlugin({ client }) {
   const CLIENT_ID = "Iv1.b507a08c87ecfe98";
   const HEADERS = {
     "User-Agent": "GitHubCopilotChat/0.35.0",
@@ -23,7 +26,7 @@ function createCopilotPlugin(client, { providerId, isEnterprise }) {
 
   return {
     auth: {
-      provider: providerId,
+      provider: "github-copilot",
       loader: async (getAuth, provider) => {
         let info = await getAuth();
         if (!info || info.type !== "oauth") return {};
@@ -117,197 +120,135 @@ function createCopilotPlugin(client, { providerId, isEnterprise }) {
           },
         };
       },
-      methods: isEnterprise
-        ? [
+      methods: [
+        {
+          type: "custom",
+          label: "Login with GitHub Copilot",
+          prompts: [
             {
-              type: "custom",
-              label: "Login with GitHub Enterprise",
-              prompts: [
+              type: "select",
+              key: "deploymentType",
+              message: "Select GitHub deployment type",
+              options: [
                 {
-                  key: "enterpriseUrl",
-                  message: "Enter your GitHub Enterprise URL or domain",
-                  placeholder: "github.company.com or https://github.company.com",
-                  validate: (value) => {
-                    if (!value) return "URL or domain is required";
-                    try {
-                      const url = value.includes("://")
-                        ? new URL(value)
-                        : new URL(`https://${value}`);
-                      if (!url.hostname)
-                        return "Please enter a valid URL or domain";
-                      return undefined;
-                    } catch {
-                      return "Please enter a valid URL (e.g., github.company.com)";
-                    }
-                  },
+                  label: "GitHub.com",
+                  value: "github.com",
+                  hint: "Public",
+                },
+                {
+                  label: "GitHub Enterprise",
+                  value: "enterprise",
+                  hint: "Data residency or self-hosted",
                 },
               ],
-              async authorize(inputs) {
-                const enterpriseUrl = inputs.enterpriseUrl;
-                const domain = normalizeDomain(enterpriseUrl);
-                const urls = getUrls(domain);
-
-                const deviceResponse = await fetch(urls.DEVICE_CODE_URL, {
-                  method: "POST",
-                  headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "GitHubCopilotChat/0.35.0",
-                  },
-                  body: JSON.stringify({
-                    client_id: CLIENT_ID,
-                    scope: "read:user",
-                  }),
-                });
-
-                if (!deviceResponse.ok) {
-                  return { type: "failed" };
-                }
-
-                const deviceData = await deviceResponse.json();
-
-                // Display URL and code for user
-                console.log(`Go to: ${deviceData.verification_uri}`);
-                console.log(`Enter code: ${deviceData.user_code}`);
-
-                // Poll for authorization
-                while (true) {
-                  await new Promise((resolve) =>
-                    setTimeout(resolve, (deviceData.interval || 5) * 1000),
-                  );
-
-                  const response = await fetch(urls.ACCESS_TOKEN_URL, {
-                    method: "POST",
-                    headers: {
-                      Accept: "application/json",
-                      "Content-Type": "application/json",
-                      "User-Agent": "GitHubCopilotChat/0.35.0",
-                    },
-                    body: JSON.stringify({
-                      client_id: CLIENT_ID,
-                      device_code: deviceData.device_code,
-                      grant_type:
-                        "urn:ietf:params:oauth:grant-type:device_code",
-                    }),
-                  });
-
-                  if (!response.ok) return { type: "failed" };
-
-                  const data = await response.json();
-
-                  if (data.access_token) {
-                    return {
-                      type: "success",
-                      auth_type: "oauth",
-                      refresh: data.access_token,
-                      access: "",
-                      expires: 0,
-                      enterpriseUrl: domain,
-                    };
-                  }
-
-                  if (data.error === "authorization_pending") {
-                    continue;
-                  }
-
-                  if (data.error) return { type: "failed" };
-                }
-              },
             },
-          ]
-        : [
             {
-              type: "oauth",
-              label: "Login with GitHub",
-              authorize: async () => {
-                const urls = getUrls("github.com");
-
-                const deviceResponse = await fetch(urls.DEVICE_CODE_URL, {
-                  method: "POST",
-                  headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                    "User-Agent": "GitHubCopilotChat/0.35.0",
-                  },
-                  body: JSON.stringify({
-                    client_id: CLIENT_ID,
-                    scope: "read:user",
-                  }),
-                });
-                const deviceData = await deviceResponse.json();
-                return {
-                  url: deviceData.verification_uri,
-                  instructions: `Enter code: ${deviceData.user_code}`,
-                  method: "auto",
-                  callback: async () => {
-                    while (true) {
-                      const response = await fetch(urls.ACCESS_TOKEN_URL, {
-                        method: "POST",
-                        headers: {
-                          Accept: "application/json",
-                          "Content-Type": "application/json",
-                          "User-Agent": "GitHubCopilotChat/0.35.0",
-                        },
-                        body: JSON.stringify({
-                          client_id: CLIENT_ID,
-                          device_code: deviceData.device_code,
-                          grant_type:
-                            "urn:ietf:params:oauth:grant-type:device_code",
-                        }),
-                      });
-
-                      if (!response.ok) return { type: "failed" };
-
-                      const data = await response.json();
-
-                      if (data.access_token) {
-                        return {
-                          type: "success",
-                          refresh: data.access_token,
-                          access: "",
-                          expires: 0,
-                        };
-                      }
-
-                      if (data.error === "authorization_pending") {
-                        await new Promise((resolve) =>
-                          setTimeout(resolve, deviceData.interval * 1000),
-                        );
-                        continue;
-                      }
-
-                      if (data.error) return { type: "failed" };
-
-                      await new Promise((resolve) =>
-                        setTimeout(resolve, deviceData.interval * 1000),
-                      );
-                      continue;
-                    }
-                  },
-                };
+              type: "text",
+              key: "enterpriseUrl",
+              message: "Enter your GitHub Enterprise URL or domain",
+              placeholder: "company.ghe.com or https://company.ghe.com",
+              condition: (inputs) => inputs.deploymentType === "enterprise",
+              validate: (value) => {
+                if (!value) return "URL or domain is required";
+                try {
+                  const url = value.includes("://")
+                    ? new URL(value)
+                    : new URL(`https://${value}`);
+                  if (!url.hostname)
+                    return "Please enter a valid URL or domain";
+                  return undefined;
+                } catch {
+                  return "Please enter a valid URL (e.g., company.ghe.com or https://company.ghe.com)";
+                }
               },
             },
           ],
+          async authorize(inputs) {
+            const deploymentType = inputs.deploymentType;
+
+            let domain = "github.com";
+            let actualProvider = "github-copilot";
+
+            if (deploymentType === "enterprise") {
+              const enterpriseUrl = inputs.enterpriseUrl;
+              domain = normalizeDomain(enterpriseUrl);
+              actualProvider = "github-copilot-enterprise";
+            }
+
+            const urls = getUrls(domain);
+
+            const deviceResponse = await fetch(urls.DEVICE_CODE_URL, {
+              method: "POST",
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+                "User-Agent": "GitHubCopilotChat/0.35.0",
+              },
+              body: JSON.stringify({
+                client_id: CLIENT_ID,
+                scope: "read:user",
+              }),
+            });
+
+            if (!deviceResponse.ok) {
+              return { type: "failed" };
+            }
+
+            const deviceData = await deviceResponse.json();
+
+            console.log(`Go to: ${deviceData.verification_uri}`);
+            console.log(`Enter code: ${deviceData.user_code}`);
+
+            while (true) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, (deviceData.interval || 5) * 1000),
+              );
+
+              const response = await fetch(urls.ACCESS_TOKEN_URL, {
+                method: "POST",
+                headers: {
+                  Accept: "application/json",
+                  "Content-Type": "application/json",
+                  "User-Agent": "GitHubCopilotChat/0.35.0",
+                },
+                body: JSON.stringify({
+                  client_id: CLIENT_ID,
+                  device_code: deviceData.device_code,
+                  grant_type:
+                    "urn:ietf:params:oauth:grant-type:device_code",
+                }),
+              });
+
+              if (!response.ok) return { type: "failed" };
+
+              const data = await response.json();
+
+              if (data.access_token) {
+                const result = {
+                  type: "success",
+                  auth_type: "oauth",
+                  refresh: data.access_token,
+                  access: "",
+                  expires: 0,
+                };
+
+                if (actualProvider === "github-copilot-enterprise") {
+                  result.provider = "github-copilot-enterprise";
+                  result.enterpriseUrl = domain;
+                }
+
+                return result;
+              }
+
+              if (data.error === "authorization_pending") {
+                continue;
+              }
+
+              if (data.error) return { type: "failed" };
+            }
+          },
+        },
+      ],
     },
   };
-}
-
-/**
- * @type {import('@opencode-ai/plugin').Plugin}
- */
-export async function CopilotAuthPlugin({ client }) {
-  return createCopilotPlugin(client, {
-    providerId: "github-copilot",
-    isEnterprise: false,
-  });
-}
-
-/**
- * @type {import('@opencode-ai/plugin').Plugin}
- */
-export async function CopilotEnterpriseAuthPlugin({ client }) {
-  return createCopilotPlugin(client, {
-    providerId: "github-copilot-enterprise",
-    isEnterprise: true,
-  });
 }


### PR DESCRIPTION
## Summary
Add support for GitHub Enterprise deployments alongside GitHub.com with a unified authentication flow.

## Changes
- Deployment type selection: GitHub.com or GitHub Enterprise
- Conditional prompt for enterprise URL (only shown when Enterprise is selected)
- Dynamic URL configuration based on deployment type
- Separate provider IDs for simultaneous GitHub.com and Enterprise logins
- Automatic token refresh for both deployments

## Implementation Details

**Deployment Configuration**:
- Uses select prompt for deployment type (GitHub.com vs Enterprise)
- Conditional text prompt for enterprise URL with validation
- Returns `provider: "github-copilot-enterprise"` for enterprise deployments
- Stores `enterpriseUrl` in auth data for API configuration

**Token Management**:
- Custom fetch function refreshes tokens automatically (~25 minute expiry)
- Determines correct provider ID from `enterpriseUrl` field when saving refreshed tokens
- Supports both `api.githubcopilot.com` and `copilot-api.<enterprise-domain>` endpoints

**URL Normalization**:
- Helper functions to normalize domain input (strips protocol and trailing slash)
- Builds GitHub OAuth and Copilot API URLs dynamically based on domain

## Related
- Requires: https://github.com/sst/opencode/pull/2522