### PR TITLE
fix: throw error on token refresh failure instead of returning undefined

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -81,7 +81,9 @@ export async function CopilotAuthPlugin({ client }) {
                 },
               });
 
-              if (!response.ok) return;
+              if (!response.ok) {
+                throw new Error(`Token refresh failed: ${response.status}`);
+              }
 
               const tokenData = await response.json();
 


### PR DESCRIPTION
Fixes sst/opencode#2012

When token refresh fails, the custom fetch returns `undefined` instead of throwing. This causes `TypeError: undefined is not an object (evaluating 'response.headers')` in the AI SDK.

This change throws an error instead, which opencode's retry logic handles automatically.