### PR TITLE
Fix inconsistent credit consumption in chat

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -118,9 +118,10 @@ export async function CopilotAuthPlugin({ client }) {
                   ? JSON.parse(init.body)
                   : init.body;
               if (body?.messages) {
-                isAgentCall = body.messages.some(
-                  (msg) => msg.role && ["tool", "assistant"].includes(msg.role),
-                );
+                if (body.messages.length > 0) {
+                  const lastMessage = body.messages[body.messages.length - 1];
+                  isAgentCall = lastMessage.role && ["tool", "assistant"].includes(lastMessage.role);
+                }
                 isVisionRequest = body.messages.some(
                   (msg) =>
                     Array.isArray(msg.content) &&


### PR DESCRIPTION
Refactor `isAgentCall` logic to check only the last message in the history rather than any message. This prevents valid user messages from being incorrectly flagged as agent calls due to previous assistant history, ensuring proper credit consumption for multi-turn conversations.

Fixes #9